### PR TITLE
Stop circumvention via dynamically created iframes

### DIFF
--- a/contentscript.js
+++ b/contentscript.js
@@ -72,8 +72,9 @@ if (
     return false;
 }
 
-// Only for http/https documents.
-if ( /^https?:/.test(window.location.protocol) !== true ) {
+// Only for dynamically created frames and http/https documents.
+if ( window.location.href !== "about:blank" &&
+     /^https?:/.test(window.location.protocol) !== true ) {
     return false;
 }
 

--- a/manifest.json
+++ b/manifest.json
@@ -9,6 +9,7 @@
   "content_scripts": [
     {
       "matches": ["http://*/*", "https://*/*"],
+      "match_about_blank": true,
       "js": ["contentscript.js"],
       "run_at": "document_start",
       "all_frames": true


### PR DESCRIPTION
Here you go, this seems to stop [the dynamic iframe circumvention aproach](https://github.com/gorhill/chromium-websocket-wrapper/issues/2) you showed me.

```
// Attempt circumvention
var element = document.createElement("iframe");
document.documentElement.appendChild(element);
if (element.contentWindow.WebSocket)
  WebSocket = element.contentWindow.WebSocket;

// Still blocked
new WebSocket("ws://ws.bulletproofserving.com:6001/");
```

Cheers, Dave.